### PR TITLE
AsyncMethodNamesShouldBeSuffixedWithAsyn: fix NRE probably

### DIFF
--- a/Source/RoslynAnalyzers/Analyzers/CodeAnalysis/Async/AsyncMethodNamesShouldBeSuffixedWithAsync/AsyncMethodNamesShouldBeSuffixedWithAsyncDiagnosticAnalyzer.cs
+++ b/Source/RoslynAnalyzers/Analyzers/CodeAnalysis/Async/AsyncMethodNamesShouldBeSuffixedWithAsync/AsyncMethodNamesShouldBeSuffixedWithAsyncDiagnosticAnalyzer.cs
@@ -42,10 +42,15 @@ namespace Analyzers.CodeAnalysis.Async.AsyncMethodNamesShouldBeSuffixedWithAsync
             if (!result.success) return;
 
             var methodDeclaration = result.syntaxNode;
-            var semanticModel = context.SemanticModel;
-            var methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration, context.CancellationToken);
+            if (methodDeclaration == null) return;
 
+            var semanticModel = context.SemanticModel;
+            if (semanticModel == null) return;
+
+            var methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration, context.CancellationToken);
+            if (methodSymbol == null) return;
             if (!methodSymbol.ReturnsTask() && !methodSymbol.IsAsync) return;
+            if (methodSymbol.Name == null) return;
             if (methodSymbol.Name.EndsWith(AsyncConstants.AsyncSuffix, StringComparison.Ordinal)) return;
 
             context.ReportDiagnostic(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation()));


### PR DESCRIPTION
My build logs full of 

```
4>CSC : warning AD0001: Analyzer 'Analyzers.CodeAnalysis.Async.AsyncMethodNamesShouldBeSuffixedWithAsync.AsyncMethodNamesShouldBeSuffixedWithAsyncDiagnosticAnalyzer' threw an exception of type 'System.NullReferenceException' with message 'Object reference not set to an instance of an object.'.
```

Due to uncertainity where is NRE and what is null actually, I choose to guard everything possible blindly.

Please could you review this PR and publish new version of the nuget if you will be OK with these fixes?

fix #5